### PR TITLE
use codecov action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,8 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
-        pipenv run pytest --cov=btq btq/tests/ -v --codecov
+        pipenv run pytest --cov=btq btq/tests/ -v
+    - uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+        verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,6 @@ jobs:
         pipenv run pytest --cov=btq btq/tests/ -v
     - uses: codecov/codecov-action@v1
       with:
+        files:  .coverage
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
       with:
         files:  .coverage
         fail_ci_if_error: true
-        verbose: true
+        verbose: false


### PR DESCRIPTION
Public PRs are failing because the secret is not available. Use the GH action that works without tokens.